### PR TITLE
0.3.2.0 Timeout support

### DIFF
--- a/VllmClient/VllmClient/AsyncVllmClient.cs
+++ b/VllmClient/VllmClient/AsyncVllmClient.cs
@@ -24,7 +24,12 @@ public class AsyncVllmClient : IDisposable
             throw new Exception("Please remove /generate from the end of API URL");
         }
 
-        client = new HttpClient { BaseAddress = new Uri(apiUrl) };
+        client = new HttpClient {BaseAddress = new Uri(apiUrl)};
+    }
+
+    public AsyncVllmClient(HttpClient httpClient)
+    {
+        client = httpClient;
     }
 
     public void Dispose()
@@ -133,29 +138,30 @@ public class AsyncVllmClient : IDisposable
     {
         var payload = new Dictionary<string, object?>()
         {
-            { "prompt", prompt },
-            { "stream", stream },
-            { "n", @params.N },
-            { "best_of", @params.BestOf },
-            { "presence_penalty", @params.PresencePenalty },
-            { "frequency_penalty", @params.FrequencyPenalty },
-            { "repetition_penalty", @params.RepetitionPenalty },
-            { "temperature", @params.Temperature },
-            { "top_p", @params.TopP },
-            { "top_k", @params.TopK },
-            { "min_p", @params.MinP },
-            { "use_beam_search", @params.UseBeamSearch },
-            { "length_penalty", @params.LengthPenalty },
-            { "early_stopping", @params.EarlyStopping },
-            { "stop", @params.Stop == null ? null : @params.Stop.Count == 1 ? @params.Stop[0] : @params.Stop },
-            { "stop_token_ids", @params.StopTokenIds },
-            { "include_stop_str_in_output", @params.IncludeStopStrInOutput },
-            { "ignore_eos", @params.IgnoreEos },
-            { "max_tokens", @params.MaxTokens },
-            { "logprobs", @params.Logprobs },
-            { "prompt_logprobs", @params.PromptLogprobs },
-            { "skip_special_tokens", @params.SkipSpecialTokens },
-            { "spaces_between_special_tokens", @params.SpacesBetweenSpecialTokens },
+            {"prompt", prompt},
+            {"stream", stream},
+            {"n", @params.N},
+            {"best_of", @params.BestOf},
+            {"presence_penalty", @params.PresencePenalty},
+            {"frequency_penalty", @params.FrequencyPenalty},
+            {"repetition_penalty", @params.RepetitionPenalty},
+            {"temperature", @params.Temperature},
+            {"top_p", @params.TopP},
+            {"top_k", @params.TopK},
+            {"min_p", @params.MinP},
+            {"seed", @params.Seed},
+            {"use_beam_search", @params.UseBeamSearch},
+            {"length_penalty", @params.LengthPenalty},
+            {"early_stopping", @params.EarlyStopping},
+            {"stop", @params.Stop == null ? null : @params.Stop.Count == 1 ? @params.Stop[0] : @params.Stop},
+            {"stop_token_ids", @params.StopTokenIds},
+            {"include_stop_str_in_output", @params.IncludeStopStrInOutput},
+            {"ignore_eos", @params.IgnoreEos},
+            {"max_tokens", @params.MaxTokens},
+            {"logprobs", @params.Logprobs},
+            {"prompt_logprobs", @params.PromptLogprobs},
+            {"skip_special_tokens", @params.SkipSpecialTokens},
+            {"spaces_between_special_tokens", @params.SpacesBetweenSpecialTokens},
         };
 
         if (extra != null)

--- a/VllmClient/VllmClient/SamplingParams.cs
+++ b/VllmClient/VllmClient/SamplingParams.cs
@@ -20,6 +20,7 @@ public class SamplingParams
     public float TopP { get; set; } = 1f;
     public int TopK { get; set; } = -1;
     public float MinP { get; set; } = 0f;
+    public int? Seed { get; set; }
     public bool UseBeamSearch { get; set; }
     public float LengthPenalty { get; set; } = 1f;
     public EarlyStopping EarlyStopping { get; set; } = EarlyStopping.Heuristic;
@@ -27,7 +28,7 @@ public class SamplingParams
     public IList<int>? StopTokenIds { get; set; }
     public bool IncludeStopStrInOutput { get; set; }
     public bool IgnoreEos { get; set; }
-    public int MaxTokens { get; set; } = 16;
+    public int? MaxTokens { get; set; } = 16;
     public int? Logprobs { get; set; }
     public int? PromptLogprobs { get; set; }
     public bool SkipSpecialTokens { get; set; } = true;

--- a/VllmClient/VllmClient/VllmClient.csproj
+++ b/VllmClient/VllmClient/VllmClient.csproj
@@ -4,8 +4,8 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <AssemblyVersion>0.2.7.2</AssemblyVersion>
-        <Version>0.2.7.2</Version>
+        <AssemblyVersion>0.3.2.0</AssemblyVersion>
+        <Version>0.3.2.0</Version>
         <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0.html</PackageLicenseUrl>
         <Title>vLLM Client</Title>
         <Description>Client for the vLLM engine. </Description>

--- a/VllmClient/VllmClientTest/AsyncVllmClientTest.cs
+++ b/VllmClient/VllmClientTest/AsyncVllmClientTest.cs
@@ -2,7 +2,7 @@ namespace VllmClientTest;
 
 public class AsyncVllmClientTest
 {
-    private const string ApiUrl = "http://localhost:8000";
+    private string ApiUrl => Environment.GetEnvironmentVariable("VLLM_BASE_URL") ?? "http://localhost:8000";
     private const string Prompt = "This is an inteview with a biologist. Reporter: How many fingers humans have on one hand? Biologist: ";
 
     private AsyncVllmClient? client;

--- a/VllmClient/VllmClientTest/VllmClientTest.csproj
+++ b/VllmClient/VllmClientTest/VllmClientTest.csproj
@@ -7,9 +7,9 @@
 
         <IsPackable>false</IsPackable>
 
-        <AssemblyVersion>0.2.7.2</AssemblyVersion>
+        <AssemblyVersion>0.3.2.0</AssemblyVersion>
 
-        <Version>0.2.7.2</Version>
+        <Version>0.3.2.0</Version>
 
         <Title>vLLM Client Tests</Title>
 

--- a/tests/test_vllm_client.py
+++ b/tests/test_vllm_client.py
@@ -1,7 +1,19 @@
+import os
 import unittest
 import asyncio
+import aiohttp
 
 from vllm_client import AsyncVllmClient, SamplingParams
+
+VLLM_BASE_URL = os.environ.get('VLLM_BASE_URL', 'http://127.0.0.1:8000')
+
+# Suitable for Llama 2
+PROMPT_TEMPLATE = '''\
+<s>[INST] <<SYS>>
+{system}
+<</SYS>>
+
+{instruction} [/INST]'''
 
 
 class VllmClientTest(unittest.IsolatedAsyncioTestCase):
@@ -12,38 +24,33 @@ class VllmClientTest(unittest.IsolatedAsyncioTestCase):
 
     """
 
-    api_base = 'http://localhost:8000'
-
-    prompt_template = '''\
-<s>[INST] <<SYS>>
-{system}
-<</SYS>>
-
-{instruction} [/INST]'''
-
     def setUp(self) -> None:
         super().setUp()
 
-        self.client = AsyncVllmClient(self.api_base)
+        self.client = AsyncVllmClient(VLLM_BASE_URL)
 
-        self.prompt = self.prompt_template.format(
-            system='Below is an instruction that describes a task. Write a response that appropriately completes the request.',
-            instruction='You are a sci-fi fan who loves old fiction. What are your favorite books?'
+        self.prompt = PROMPT_TEMPLATE.format(
+            system='Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n',
+            instruction='You are a sci-fi fan who loves old fiction. What are your 10 favorite books?'
         )
 
     async def test_single_generation(self):
         n = 3
         count = 0
-        for s in await self.client.generate(self.prompt, SamplingParams(n=n, temperature=0.7, max_tokens=300)):
-            print(s[len(self.prompt):])
+        params = SamplingParams(n=n, temperature=0.7, max_tokens=300)
+        for completion in await self.client.generate(self.prompt, params):
+            generated = completion[len(self.prompt):]
+            print(generated)
             print()
+            self.assertGreaterEqual(len(generated), 20)
             count += 1
         self.assertEqual(n, count)
 
     async def test_streaming_generation(self):
         received = self.prompt
-        async for d in self.client.stream(self.prompt, SamplingParams(temperature=0.7, max_tokens=300)):
-            output = d[0]
+        params = SamplingParams(temperature=0.7, max_tokens=300)
+        async for completions in self.client.stream(self.prompt, params):
+            output = completions[0]
             print(output[len(received):], end='')
             received = output
         self.assertGreater(len(received), len(self.prompt) + 100)
@@ -59,3 +66,23 @@ class VllmClientTest(unittest.IsolatedAsyncioTestCase):
             print()
             count += 1
         self.assertEqual(n, count)
+
+    async def test_single_extra(self):
+        n = 3
+        count = 0
+        params = SamplingParams(n=n, temperature=0.7, max_tokens=300)
+        for completion in await self.client.generate(self.prompt, params, extra=dict(max_tokens=3)):
+            generated = completion[len(self.prompt):]
+            print(generated)
+            print()
+            count += 1
+            self.assertLess(len(generated), 20)
+        self.assertEqual(n, count)
+
+    async def test_single_timeout(self):
+        params = SamplingParams(n=16, temperature=0.7, max_tokens=3000)
+        try:
+            for _ in await self.client.generate(self.prompt, params, timeout=aiohttp.ClientTimeout(total=0.1)):
+                self.fail('Did not time out')
+        except asyncio.TimeoutError:
+            self.assertTrue(True)

--- a/vllm_client/__init__.py
+++ b/vllm_client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.7.2"
+__version__ = "0.3.2.0"
 
 from .async_client import AsyncVllmClient
 from .sampling_params import SamplingParams

--- a/vllm_client/sampling_params.py
+++ b/vllm_client/sampling_params.py
@@ -40,6 +40,7 @@ class SamplingParams:
         min_p: Float that represents the minimum probability for a token to be
             considered, relative to the probability of the most likely token.
             Must be in [0, 1]. Set to 0 to disable this.
+        seed: Random seed to use for the generation.
         use_beam_search: Whether to use beam search instead of sampling.
         length_penalty: Float that penalizes sequences based on their length.
             Used in beam search.
@@ -83,6 +84,7 @@ class SamplingParams:
             top_p: float = 1.0,
             top_k: int = -1,
             min_p: float = 0.0,
+            seed: Optional[int] = None,
             use_beam_search: bool = False,
             length_penalty: float = 1.0,
             early_stopping: Union[bool, str] = False,
@@ -90,7 +92,7 @@ class SamplingParams:
             stop_token_ids: Optional[List[int]] = None,
             include_stop_str_in_output: bool = False,
             ignore_eos: bool = False,
-            max_tokens: int = 16,
+            max_tokens: Optional[int] = 16,
             logprobs: Optional[int] = None,
             prompt_logprobs: Optional[int] = None,
             skip_special_tokens: bool = True,
@@ -105,6 +107,7 @@ class SamplingParams:
         self.top_p = top_p
         self.top_k = top_k
         self.min_p = min_p
+        self.seed = seed
         self.use_beam_search = use_beam_search
         self.length_penalty = length_penalty
         self.early_stopping = early_stopping
@@ -163,7 +166,7 @@ class SamplingParams:
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError("min_p must be in [0, 1], got "
                              f"{self.min_p}.")
-        if self.max_tokens < 1:
+        if self.max_tokens is not None and self.max_tokens < 1:
             raise ValueError(
                 f"max_tokens must be at least 1, got {self.max_tokens}.")
         if self.logprobs is not None and self.logprobs < 0:
@@ -218,6 +221,7 @@ class SamplingParams:
             f"top_p={self.top_p}, "
             f"top_k={self.top_k}, "
             f"min_p={self.min_p}, "
+            f"seed={self.seed}, "
             f"use_beam_search={self.use_beam_search}, "
             f"length_penalty={self.length_penalty}, "
             f"early_stopping={self.early_stopping}, "


### PR DESCRIPTION
- `SamplingParams` to match vLLM 0.3.2
- Timeout support in Python API
- Custom `HttpClient` (with timeout) support in C# API
- The tests to use the `VLLM_BASE_URL` environment variable
- More Python tests